### PR TITLE
Bugfix: search bypasses conditions

### DIFF
--- a/src/Adapters/QueryBuilder.php
+++ b/src/Adapters/QueryBuilder.php
@@ -4,6 +4,9 @@ use Phalcon\Paginator\Adapter\QueryBuilder as PQueryBuilder;
 
 class QueryBuilder extends AdapterInterface{
   protected $builder;
+  private $global_search;
+  private $column_search;
+  private $_bind;
 
   public function setBuilder($builder) {
     $this->builder = $builder;
@@ -17,13 +20,17 @@ class QueryBuilder extends AdapterInterface{
     ]);
 
     $total = $builder->getPaginate();
+    $this->global_search = [];
+    $this->column_search = [];
 
     $this->bind('global_search', function($column, $search) {
-      $this->builder->orWhere("{$column} LIKE :key_{$column}:", ["key_{$column}" => "%{$search}%"]);
+      $this->global_search[] = "{$column} LIKE :keyg_{$column}:";
+      $this->_bind["keyg_" . $column] = "%{$search}%";
     });
 
     $this->bind('column_search', function($column, $search) {
-      $this->builder->andWhere("{$column} LIKE :key_{$column}:", ["key_{$column}" => "%{$search}%"]);
+      $this->column_search[] = "{$column} LIKE :keyc_{$column}:";
+      $this->_bind["keyc_" . $column] = "%{$search}%";
     });
 
     $this->bind('order', function($order) {
@@ -32,9 +39,16 @@ class QueryBuilder extends AdapterInterface{
       }
     });
 
+    if (!empty($this->global_search) || !empty($this->column_search)) {
+      $where = implode(' OR ', $this->global_search);
+      if (!empty($this->column_search))
+        $where = (empty($where) ? '' : ('(' . $where . ') AND ')) . implode(' AND ', $this->column_search);
+      $this->builder->andWhere($where, $this->_bind);
+    }
+
     $builder = new PQueryBuilder([
       'builder' => $this->builder,
-      'limit'   => $this->parser->getLimit(),
+      'limit'   => $this->parser->getLimit($total->total_items),
       'page'    => $this->parser->getPage(),
     ]);
 


### PR DESCRIPTION
$builder = $this->modelsManager->createBuilder()
                    ->columns('id, name')
                    ->from('Orders')
                    ->where('client_id=' . $client_id);
$dataTables = new DataTable();
$dataTables->fromBuilder($builder)->sendResponse();

This code should show orders by client id. however, when the client uses datatables's search, the results shows all clients orders that matches the search (bypassing my condition).

This commit should fix that.
